### PR TITLE
Fix bug with Number of Icons input not validating

### DIFF
--- a/src/component/Input.tsx
+++ b/src/component/Input.tsx
@@ -2,7 +2,7 @@ export function Input(props: React.ComponentPropsWithoutRef<"input">) {
   return (
     <input
       {...props}
-      type="text"
+      type={props.type || 'text'}
       className="rounded border border-gray-800 px-4 py-2 dark:text-gray-800"
     ></input>
   );

--- a/src/pages/generate.tsx
+++ b/src/pages/generate.tsx
@@ -96,13 +96,13 @@ const GeneratePage: NextPage = () => {
           <FormGroup className="mb-12 grid grid-cols-4">
             {colors.map((color) => (
               <label key={color} className="flex gap-2 text-2xl">
-                <input
+                <Input
                   required
                   type="radio"
                   name="color"
                   checked={color === form.color}
                   onChange={() => setForm((prev) => ({ ...prev, color }))}
-                ></input>
+                ></Input>
                 {color}
               </label>
             ))}
@@ -112,13 +112,13 @@ const GeneratePage: NextPage = () => {
           <FormGroup className="mb-12 grid grid-cols-4">
             {shapes.map((shape) => (
               <label key={shape} className="flex gap-2 text-2xl">
-                <input
+                <Input
                   required
                   type="radio"
                   name="shape"
                   checked={shape === form.shape}
                   onChange={() => setForm((prev) => ({ ...prev, shape }))}
-                ></input>
+                ></Input>
                 {shape}
               </label>
             ))}
@@ -128,13 +128,13 @@ const GeneratePage: NextPage = () => {
           <FormGroup className="mb-12 grid grid-cols-4">
             {styles.map((style) => (
               <label key={style} className="flex gap-2 text-2xl">
-                <input
+                <Input
                   required
                   type="radio"
                   name="style"
                   checked={style === form.style}
                   onChange={() => setForm((prev) => ({ ...prev, style }))}
-                ></input>
+                ></Input>
                 {style}
               </label>
             ))}

--- a/src/pages/generate.tsx
+++ b/src/pages/generate.tsx
@@ -144,8 +144,7 @@ const GeneratePage: NextPage = () => {
           <FormGroup className="mb-12">
             <label>Number of icons</label>
             <Input
-              inputMode="numeric"
-              pattern="[1-9]|10"
+              type="number"
               value={form.numberOfIcons}
               required
               onChange={updateForm("numberOfIcons")}


### PR DESCRIPTION
Noticed this while working my way through your course the reason the number of icons input wasn't validating correctly was that is was using the custom `<Input>` from Input.tsx which had `type="text"` hardcoded into it rather than taking it in as an optional prop.

- Updated Input.tsx to take `type` as an optional prop or default to text
- Updated all inputs on the generate page to use the custom Input